### PR TITLE
[*] MO : blockadvertising remove line helper->id in blockadvertising.php

### DIFF
--- a/blockadvertising.php
+++ b/blockadvertising.php
@@ -268,7 +268,6 @@ class BlockAdvertising extends Module
 		$helper->default_form_language = $lang->id;
 		$helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
 		$this->fields_form = array();
-		$helper->id = (int)Tools::getValue('id_carrier');
 		$helper->identifier = $this->identifier;
 		$helper->submit_action = 'submitAdvConf';
 		$helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false).'&configure='.$this->name.'&tab_module='.$this->tab.'&module_name='.$this->name;


### PR DESCRIPTION
Remove  $helper->id = (int)Tools::getValue('id_carrier');
id_carrier doesn't exist